### PR TITLE
Do not delete sourcemaps working

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,7 @@ build=$(cd "$1/" && pwd)
 cache=$(cd "$2/" && pwd)
 env_dir=$(cd "$3/" && pwd)
 
-for key in SENTRY_AUTH_TOKEN SENTRY_ORG SENTRY_PROJECT SENTRY_SOURCE_MAP_PREFIX; do
+for key in SENTRY_AUTH_TOKEN SENTRY_ORG SENTRY_PROJECT; do
     [[ -f "${env_dir}/${key}" ]] && export "$key=$(cat "${env_dir}/${key}")"
     [[ -z "${!key}" ]] && echo "-----> ${key} is missing or empty: unable to continue." && exit 1
 done
@@ -46,7 +46,7 @@ cd "${build}/"
 
 for map in $(find . -name '*.js.map' -not -path './node_modules/*' -not -path './.heroku/*' | cut -c 3-); do
     sum=$(sha1sum "./${map}" | cut -c -40)
-    name="${SENTRY_SOURCE_MAP_PREFIX}/${map}"
+    name="${map}"
     
     # Check if we have a '.next' directory for Next.js
     # Need to modify $name to represent with BUILD_ID from Next.js
@@ -59,7 +59,7 @@ for map in $(find . -name '*.js.map' -not -path './node_modules/*' -not -path '.
     res=($(${JQ} -r ". | map(select(.name == \"${name}\")) | first | .id + \" \" + (.sha1 // \"\")" "${files}"))
 
     if [[ "${res[0]}" == "" ]]; then
-        echo "       Uploading ${map} to Sentry"
+        echo "       Uploading ${map} to Sentry. Using name as ${name}"
         curl -sSf "${API}/releases/${SOURCE_VERSION}/files/" \
              -X POST \
              -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
@@ -68,7 +68,7 @@ for map in $(find . -name '*.js.map' -not -path './node_modules/*' -not -path '.
              >/dev/null
 
     elif [[ "${res[1]}" != "${sum}" ]]; then
-        echo "       Updating ${map} on Sentry"
+        echo "       Updating ${map} on Sentry. Using name as ${name}"
         curl -sSf "${API}/releases/${SOURCE_VERSION}/files/${res[0]}/" \
              -X DELETE \
              -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
@@ -81,7 +81,7 @@ for map in $(find . -name '*.js.map' -not -path './node_modules/*' -not -path '.
              >/dev/null
 
     else
-        echo "       ${map} is up-to-date"
+      echo "       ${map} is up-to-date (${name})"
     fi
 done
 

--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,7 @@ build=$(cd "$1/" && pwd)
 cache=$(cd "$2/" && pwd)
 env_dir=$(cd "$3/" && pwd)
 
-for key in SENTRY_AUTH_TOKEN SENTRY_ORG SENTRY_PROJECT; do
+for key in SENTRY_AUTH_TOKEN SENTRY_ORG SENTRY_PROJECT SENTRY_SOURCE_MAP_PREFIX; do
     [[ -f "${env_dir}/${key}" ]] && export "$key=$(cat "${env_dir}/${key}")"
     [[ -z "${!key}" ]] && echo "-----> ${key} is missing or empty: unable to continue." && exit 1
 done
@@ -46,7 +46,7 @@ cd "${build}/"
 
 for map in $(find . -name '*.js.map' -not -path './node_modules/*' -not -path './.heroku/*' | cut -c 3-); do
     sum=$(sha1sum "./${map}" | cut -c -40)
-    name="~/${map}"
+    name="${SENTRY_SOURCE_MAP_PREFIX}/${map}"
     
     # Check if we have a '.next' directory for Next.js
     # Need to modify $name to represent with BUILD_ID from Next.js

--- a/bin/compile
+++ b/bin/compile
@@ -46,7 +46,7 @@ cd "${build}/"
 
 for map in $(find . -name '*.js.map' -not -path './node_modules/*' -not -path './.heroku/*' | cut -c 3-); do
     sum=$(sha1sum "./${map}" | cut -c -40)
-    name="${map}"
+    name=$(echo ${map} | cut -d/ -f 2-)
     
     # Check if we have a '.next' directory for Next.js
     # Need to modify $name to represent with BUILD_ID from Next.js

--- a/bin/compile
+++ b/bin/compile
@@ -83,9 +83,9 @@ for map in $(find . -name '*.js.map' -not -path './node_modules/*' -not -path '.
     else
       echo "       ${map} is up-to-date (${name})"
     fi
-    rm ${map}
+    # rm ${map}
 done
 
-# rm "${files}"
+rm "${files}" # Deletes the temporary file created above
 
 echo "       Done!"

--- a/bin/compile
+++ b/bin/compile
@@ -83,6 +83,7 @@ for map in $(find . -name '*.js.map' -not -path './node_modules/*' -not -path '.
     else
       echo "       ${map} is up-to-date (${name})"
     fi
+    rm ${map}
 done
 
 rm "${files}"

--- a/bin/compile
+++ b/bin/compile
@@ -86,6 +86,6 @@ for map in $(find . -name '*.js.map' -not -path './node_modules/*' -not -path '.
     rm ${map}
 done
 
-rm "${files}"
+# rm "${files}"
 
 echo "       Done!"

--- a/bin/compile
+++ b/bin/compile
@@ -46,7 +46,7 @@ cd "${build}/"
 
 for map in $(find . -name '*.js.map' -not -path './node_modules/*' -not -path './.heroku/*' | cut -c 3-); do
     sum=$(sha1sum "./${map}" | cut -c -40)
-    name=$(echo ${map} | cut -d/ -f 2-)
+    name="~/$(echo ${map} | cut -d/ -f 2-)"
     
     # Check if we have a '.next' directory for Next.js
     # Need to modify $name to represent with BUILD_ID from Next.js


### PR DESCRIPTION
The previous PR had an issue. Instead of preventing deletion of map files, we were preventing deletion of the temporary file. This PR addresses the problem